### PR TITLE
Add width attribute by default

### DIFF
--- a/makecards.c
+++ b/makecards.c
@@ -55,7 +55,7 @@ int backmargin = 0;
 int pattern = -1;
 int number = 0;
 int fontsize = 20;
-int widthonuse = 0;
+int nowidthonuse = 0;
 int writeinline = 0;
 int jokers = 2;
 int blanks = 0;
@@ -183,7 +183,7 @@ adddefB (xml_t e, char value)
       xml_add (pat, "@id", id);
       xml_add (pat, "@width", tho (THO * pattern));
       xml_add (pat, "@height", tho (THO * pattern));
-      if (widthonuse)
+      if (!nowidthonuse)
          xml_add (pat, "@width", tho (THO * pattern));
       xml_add (pat, "@patternUnits", "userSpaceOnUse");
       if (!strcasecmp (back, "Illusion"))
@@ -588,7 +588,7 @@ makecourt (xml_t root, char suit, char value)
             {                   // Outline for black on black, or white background for grey
                xml_t x = addsymbolsuit (symbol, suit, value, &notfilled);
                xml_addf (x, "@height", "%d", pips[n][p].s);
-               if (widthonuse)
+               if (!nowidthonuse)
                   xml_addf (x, "@width", "%d", pips[n][p].s);
                xml_addf (x, "@transform", "translate(%d,%d)scale(1,%s)rotate(%d)translate(%d,%d)", pips[n][p].x, 2000 - pips[n][p].y, tho (THO * 20ULL * bw / 13ULL / bh), pips[n][p].r, -pips[n][p].s / 2, -pips[n][p].s / 2);
                xml_add (x, "@fill", "none");
@@ -603,7 +603,7 @@ makecourt (xml_t root, char suit, char value)
 
             xml_t x = addsymbolsuit (symbol, suit, value, &notfilled);
             xml_addf (x, "@height", "%d", pips[n][p].s);
-            if (widthonuse)
+            if (!nowidthonuse)
                xml_addf (x, "@width", "%d", pips[n][p].s);
             xml_addf (x, "@transform", "translate(%d,%d)scale(1,%s)rotate(%d)translate(%d,%d)", pips[n][p].x, 2000 - pips[n][p].y, tho (THO * 20ULL * bw / 13ULL / bh), pips[n][p].r, -pips[n][p].s / 2, -pips[n][p].s / 2);
             if (notfilled)
@@ -842,7 +842,7 @@ makeback (int n, char suit, char value)
       {
          xml_t logo = addsymbolFB (root);
          xml_add (logo, "@height", tho (THO * h / 3));
-         if (widthonuse)
+         if (!nowidthonuse)
             xml_add (logo, "@width", tho (THO * h / 3));
          xml_add (logo, "@x", tho (-THO * h / 5));
          xml_add (logo, "@y", tho (-THO * h / 3 - THO * h / 12));
@@ -850,7 +850,7 @@ makeback (int n, char suit, char value)
          logo = addsymbolFB (root);
          xml_add (logo, "@transform", "rotate(180)");
          xml_add (logo, "@height", tho (THO * h / 3));
-         if (widthonuse)
+         if (!nowidthonuse)
             xml_add (logo, "@width", tho (THO * h / 3));
          xml_add (logo, "@x", tho (-THO * h / 5));
          xml_add (logo, "@y", tho (-THO * h / 3 - THO * h / 12));
@@ -891,7 +891,7 @@ makeback (int n, char suit, char value)
                h = bw - THO * pattern * 2;
             xml_t logo = addsymbolAA (root);
             xml_add (logo, "@height", tho (h));
-            if (widthonuse)
+            if (!nowidthonuse)
                xml_add (logo, "@width", tho (h));
             xml_add (logo, "@x", tho (-h / 2));
             xml_add (logo, "@y", tho (-h / 2));
@@ -909,7 +909,7 @@ makeback (int n, char suit, char value)
                xml_t logo = addsymbolAA (g),
                   t;
                xml_add (logo, "@height", tho (w));
-               if (widthonuse)
+               if (!nowidthonuse)
                   xml_add (logo, "@width", tho (w));
                xml_add (logo, "@x", tho (-h));
                xml_add (logo, "@y", tho (-w));
@@ -997,7 +997,7 @@ makecard (char suit, char value)
       if (box && (indexonly || plain || !strchr ("JQK", value)) && ((!*ace1 && !*ace2) || !strcasecmp (ace, "Goodall") || (!one && suit != 'S') || value != 'A' || indexonly || plain))
       {                         // Box (background)
          xml_t box = adddefX (root, bw, bh, suit, value);
-         if (widthonuse)
+         if (!nowidthonuse)
          {
             xml_add (box, "@width", tho (bw));
             xml_add (box, "@height", tho (bh));
@@ -1007,7 +1007,7 @@ makecard (char suit, char value)
       } else if (frontcolour && strchr ("JQK", value) && !plain && !indexonly)
       {                         // Court background white
          xml_t box = adddefX (root, bw, bh, suit, value);
-         if (widthonuse)
+         if (!nowidthonuse)
          {
             xml_add (box, "@width", tho (bw));
             xml_add (box, "@height", tho (bh));
@@ -1047,7 +1047,7 @@ makecard (char suit, char value)
          if (notfilled && !ghost)
             xml_add (p, "@fill", colour[s - suits]);
          xml_add (p, "@height", tho (h));
-         if (widthonuse)
+         if (!nowidthonuse)
             xml_add (p, "@width", tho (h));
          xml_add (p, "@x", tho (x));
          xml_add (p, "@y", tho (y));
@@ -1112,7 +1112,7 @@ makecard (char suit, char value)
             {                   // Corner
                xml_t x = addsymbolvalue (g, suit, value);
                xml_add (x, "@height", tho (THO * vh));
-               if (widthonuse)
+               if (!nowidthonuse)
                   xml_add (x, "@width", tho (THO * vh));
                xml_add (x, "@x", tho (-THO * w / 2 + THO * margin - THO * vh / 5));
                xml_add (x, "@y", tho (-THO * h / 2 + THO * (topmargin > corner ? topmargin : corner)));
@@ -1121,7 +1121,7 @@ makecard (char suit, char value)
             {
                xml_t x = addsymbolvalue (g, suit, value);
                xml_add (x, "@height", tho (THO * vh));
-               if (widthonuse)
+               if (!nowidthonuse)
                   xml_add (x, "@width", tho (THO * vh));
                xml_add (x, "@x", tho (THO * w / 2 - THO * margin + THO * vh / 5 - THO * vh));
                xml_add (x, "@y", tho (-THO * h / 2 + THO * (topmargin > corner ? topmargin : corner)));
@@ -1190,7 +1190,7 @@ makecard (char suit, char value)
          {
             xml_t x = addsymbolvalue (g, suit, value);
             xml_add (x, "@height", tho (bw));
-            if (widthonuse)
+            if (!nowidthonuse)
                xml_add (x, "@width", tho (bw));
             xml_add (x, "@x", tho (-bw / 2));
             xml_add (x, "@y", tho (-bw / 2));
@@ -1420,7 +1420,7 @@ main (int argc, const char *argv[])
          {"suffix", 0, POPT_ARG_STRING, &suffix, 0, "Filename suffix", "text"}, //
          {"duplimate", 0, POPT_ARG_STRING, &duplimate, 0, "Barcode", "licence no"},     //
          {"aspect", 0, POPT_ARG_NONE, &aspect, 0, "Fix aspect ratio of court cards"},   //
-         {"width-on-use", 0, POPT_ARG_NONE, &widthonuse, 0, "Width on use objects (for wikimedia)"},    //
+         {"no-width-on-use", 0, POPT_ARG_NONE, &nowidthonuse, 0, "No width attribute on use objects"},  //
          {"card", 0, POPT_ARG_STRING, &card, 0, "One card", "[value][suit]"},   //
          {"inline", 0, POPT_ARG_NONE, &writeinline, 0, "Write to stdout"},      //
          {"jokers", 0, POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT, &jokers, 0, "Jokers", "N"},    //


### PR DESCRIPTION
[react-native-svg](https://github.com/react-native-community/react-native-svg) requires `width` attribute for `use` element to be rendered correctly.

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/width#use), the default value for `width` attribute in `use` element is `auto` (treated as `0`). And when `width` is treated as `0`, [W3C recommendation](https://www.w3.org/TR/SVG11/struct.html#UseElementWidthAttribute) says:

> A value of zero disables rendering of this element.

This pull request makes `width` attribute to be added by default. It would cause less headache for the users, who (like me) can be puzzled for hours why these SVG files are not displayed correctly with some renderers. Writing `width` attributes can be disabled by `--no-width-on-use` command line option.

Out of curiosity, what is the reason to not to use `width` attribute?